### PR TITLE
Only draw points within viewport

### DIFF
--- a/canvasDraw.js
+++ b/canvasDraw.js
@@ -401,7 +401,10 @@ function drawActualPoints(data, xScale, yScale) {
 	var drawCanvas = document.getElementById('plot-points')
 	var drawCtx = drawCanvas.getContext('2d')
 	data.forEach(function(point) {
-		drawPoint(point,drawCtx, xScale, yScale);
+		if (point.x > xScale.domain()[0] && point.x < xScale.domain()[1] 
+		   && point.y > yScale.domain()[0] && point.y < yScale.domain()[1]) {
+			drawPoint(point,drawCtx, xScale, yScale);
+		}
 	})
 }
 
@@ -730,9 +733,7 @@ function drawPlot (data,plotGeometry,plotOptions,colorMap) {
 		canvasPlot.g_transform = transform; // cache the transform
 	}
 	function zoomend() {
-		canvasPlot.data.forEach(function(point) {
-			drawPoint(point, batchCtx, canvasPlot.xScale, canvasPlot.yScale);
-		})
+		drawActualPoints(canvasPlot.data, canvasPlot.xScale, canvasPlot.yScale)
 		selectedPoints.forEach(function(dot) {
 			highlightPoint(dot, selectCtx, canvasPlot.xScale, canvasPlot.yScale);
 		})

--- a/canvasDraw.js
+++ b/canvasDraw.js
@@ -400,9 +400,13 @@ String.prototype.visualLength = function() {
 function drawActualPoints(data, xScale, yScale) {
 	var drawCanvas = document.getElementById('plot-points')
 	var drawCtx = drawCanvas.getContext('2d')
+	let xScaleMin = xScale.domain()[0]
+	let xScaleMax = xScale.domain()[1]
+	let yScaleMin = yScale.domain()[0]
+	let yScaleMax = yScale.domain()[1]
 	data.forEach(function(point) {
-		if (point.x > xScale.domain()[0] && point.x < xScale.domain()[1] 
-		   && point.y > yScale.domain()[0] && point.y < yScale.domain()[1]) {
+		if (point.x > xScaleMin && point.x < xScaleMax
+		   && point.y > yScaleMin && point.y < yScaleMax) {
 			drawPoint(point,drawCtx, xScale, yScale);
 		}
 	})


### PR DESCRIPTION
We are working improving responsiveness for large numbers of points. One simple change is to only draw points visible within the viewport. Doing so is a significant speedup for large numbers of points when zoomed in.

Example timing: with ~400,000 points, the initial draw of all the points is about 2 seconds. Zooming in to a smaller region decreases that time (depending on the zoom level) to less than 1 second.

Note: this PR is with respect to the 'quick-bug-fixes' branch (#23) rather than the main branch.